### PR TITLE
<minor>: Change .txt filename generated by ILA/VIO

### DIFF
--- a/src/ILA_VIO.scala
+++ b/src/ILA_VIO.scala
@@ -2,9 +2,12 @@ package common
 import chisel3._
 import chisel3.util._
 import firrtl.options.CustomFileEmission
+import firrtl.annotations.NoTargetAnnotation
 import firrtl.annotations.SingleTargetAnnotation
 import firrtl.annotations.ReferenceTarget
 import firrtl.AnnotationSeq
+import firrtl.options.Viewer
+import chisel3.stage.ChiselOptions
 import chisel3.experimental.{annotate,ChiselAnnotation}
 import java.io._
 
@@ -15,6 +18,10 @@ object AnnotationCount{
 	var count = 0
 }
 
+object DebugFileName{
+	var enabled = false
+	var str		= ""
+}
 
 class BaseILA(seq:Seq[Data])extends BlackBox{
 	val t = seq.map(chiselTypeOf(_))
@@ -28,6 +35,10 @@ class BaseILA(seq:Seq[Data])extends BlackBox{
 		io.data.zip(seq).foreach(node => node._1 := node._2)
 		val p = new Pack
 		val count = AnnotationCount.count
+		if (!DebugFileName.enabled) {
+			annotate(new ChiselAnnotation {def toFirrtl = DebugFileNameAnno(seq(0).toTarget)})
+			DebugFileName.enabled = true
+		}
 		seq.foreach(data => annotate(new ChiselAnnotation {def toFirrtl = MyMetadataAnno(count, name, seq.length, p, data.toTarget)}))
 		AnnotationCount.count += 1
 	}
@@ -45,6 +56,10 @@ class BaseVIO(seq:Seq[Data])extends BlackBox{
 		io.data.zip(seq).foreach(node => node._2 := node._1)
 		val p = new Pack
 		val count = AnnotationCount.count
+		if (!DebugFileName.enabled) {
+			annotate(new ChiselAnnotation {def toFirrtl = DebugFileNameAnno(seq(0).toTarget)})
+			DebugFileName.enabled = true
+		}
 		seq.foreach(data => annotate(new ChiselAnnotation {def toFirrtl = MyMetadataAnno(count, name, seq.length, p, data.toTarget)}))
 		AnnotationCount.count += 1
 	}
@@ -54,12 +69,20 @@ case class MyMetadataAnno(count:Int, name:String, l:Int, p:Pack, target:Referenc
 	def duplicate(n: ReferenceTarget) = this //this.copy(n)
 	p.targets = p.targets :+ target.serialize.split('>')(1).replace('.','_').replace('[','_').replace("]","")
 	if(l == p.targets.length){
-		val moduleName = target.circuit
-		val isAppend = count != 0
-		val	writer = new PrintWriter(new FileOutputStream(new File("Verilog/"+moduleName+".txt"), isAppend))
+		p.targets.foreach(str => DebugFileName.str += str+"\n")
+		DebugFileName.str += name+":\n"
+	}
+}
 
-		p.targets.foreach(str => writer.append(str+"\n"))
-		writer.append(name+":\n")
-		writer.close()
+case class DebugFileNameAnno(target:ReferenceTarget) extends SingleTargetAnnotation[ReferenceTarget] with CustomFileEmission {
+	def duplicate(n: ReferenceTarget) = this
+
+	protected def baseFileName(annotations: AnnotationSeq): String = {
+		return Viewer.view[ChiselOptions](annotations).outputFile.get
+	}
+	protected def suffix: Option[String] = Some(".txt")
+	def getBytes: Iterable[Byte] = {
+		DebugFileName.enabled = true
+		return DebugFileName.str.getBytes()
 	}
 }


### PR DESCRIPTION
I changed .txt filename rule of ILA/VIO. 
I find the problem when my top module name differs from output file name, which is common with partial reconfiguration. For example, my file name is "WorkerNICTop.scala" while the top module is "AlveoDynamicTop", what I expected is a "WorkerNICTop.txt" but ILA/VIO generates "AlveoDynamicTop.txt", which causes post-elaborating script working improperly. 
This patch could make the txt file follows output file name instead of top module name. This makes no difference for general usage as before, but fits my case.